### PR TITLE
Remove max_* params from test_full

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -13,9 +13,6 @@
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'
-    max_cpus   = 12
-    max_memory = 60.GB
-    max_time   = 48.h
 
     // Input data for full size test
     input = "${projectDir}/assets/test_full_samplesheet.csv"


### PR DESCRIPTION
We don't need to specify any maximum resource parameters in the `test_full` config profile.

The `test` profile is a special case for this, as we know that the data is tiny. For the full size dataset the data is not tiny though, so the maximum resources should be left as their defaults as they would be for a normal run of the pipeline.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hicar/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/hicar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
